### PR TITLE
Fixed bug in Model::toArray() with dates objects

### DIFF
--- a/src/MongoDB/Model.php
+++ b/src/MongoDB/Model.php
@@ -300,6 +300,8 @@ class Model extends \MongoDB\Collection
             if (gettype($item) == 'object') {
                 if ($item instanceof ObjectID) {
                     return (string)$item;
+                } elseif($item instanceof UTCDateTime){
+                    return $item->toDateTime()->format(DATE_ISO8601);
                 } else {
                     return (array)$item;
                 }


### PR DESCRIPTION
Dates was exported as empty arrays, probably because there is no
suitable way to convert an MongoDB\BSON\UTCDateTime object into
a PHP array. Now dates are exported in DATE_ISO8601 format.
